### PR TITLE
feat: compatibility with lambdas Amazon Linux 2 runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/*
+assets/*
 *.zip
 .idea
 *.out

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-BINARY_LINUX64=dist/token_auth-linux-amd64
+BUILD_DIR=dist
+BINARY_LINUX64=bootstrap # fixed name for provided.al2 runtime
 SOURCE=$(shell find . -name "*go" -a -not -path "./vendor/*" -not -path "./cmd/testgen/*" )
 VERSION=$(shell git describe --tags)
 
@@ -18,11 +19,15 @@ generate:
 	cd mock; go generate ; cd ..
 
 build:
-	cd cmd && GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \
-				"-s -w" -o ../$(BINARY_LINUX64)
+	mkdir -p $(BUILD_DIR)
+	cd cmd && GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -ldflags \
+				"-s -w" -o ../$(BUILD_DIR)/$(BINARY_LINUX64)
 
 assets: build
 	mkdir -p assets
-	zip assets/token_auth-${VERSION}-linux-amd64.zip $(BINARY_LINUX64) README.md
-	tar czf assets/token_auth-${VERSION}-linux-amd64.tgz $(BINARY_LINUX64) README.md
+	cp README.md $(BUILD_DIR)/README.md
+
+	cd $(BUILD_DIR); zip ../assets/token_auth-${VERSION}-linux-amd64.zip $(BINARY_LINUX64) README.md
+	cd $(BUILD_DIR); tar czf ../assets/token_auth-${VERSION}-linux-amd64.tgz $(BINARY_LINUX64) README.md
+
 	sha256sum assets/token_auth-* > assets/SHASUMS256.txt


### PR DESCRIPTION
The Go1.x runtime was deprecated by AWS and will be unavailable by the end of 2023.

There is a migration guide to use Amazon Linux 2.

Main changes: 
* The binary has to be named [`bootstrap`](https://aws.amazon.com/de/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/#:~:text=Compiling%20for%20the%20provided.al2%20runtime) in the root of the zip. There is no documented way to use a different name
* The [dependency on AWS's RPC client could be removed](https://aws.amazon.com/de/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/#:~:text=To%20remove%20the,your%20build%20command)

This is a breaking change, because it would require to change the `handler` if token-auth was used with the old Go1.x runtime.